### PR TITLE
Pin hdr libs in Dockerfile-cyclic-only file

### DIFF
--- a/photonrt_dpdk_20.03/Dockerfile-cyclic-only
+++ b/photonrt_dpdk_20.03/Dockerfile-cyclic-only
@@ -34,7 +34,7 @@ WORKDIR /root/build
 RUN git clone git://git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git
 WORKDIR /root/build/rt-tests
 ENV PATH="/root/build/rt-tests:${PATH}"
-RUN make; make install; pip3 install click matplotlib hdrhistogram hdr_plot
+RUN make; make install; pip3 install click matplotlib hdrhistogram==0.8.0 hdr_plot==0.2.3
 COPY ["utils.py", "cyclictest-plot-80us", "cyclictest-hist-to-percentiles", "cycle-test-auto", "run-cyclic-test", "./"]
 
 CMD ["ldconfig; /bin/bash"]


### PR DESCRIPTION
We need to ping hdrhistogram==0.8.0 and hdr_plot==0.2.3 otherwise cyclictest fails since the newest versions of hdr libs are not compatible with some scripts inside testnf.